### PR TITLE
Backport `AlwaysAllowMultiInstanceSplit`

### DIFF
--- a/AlwaysAllowMultiInstanceSplit/build.gradle.kts
+++ b/AlwaysAllowMultiInstanceSplit/build.gradle.kts
@@ -7,7 +7,7 @@ android {
     namespace = "de.binarynoise.AlwaysAllowMultiInstanceSplit"
     
     defaultConfig {
-        minSdk = 35
+        minSdk = 33
         targetSdk = 35
     }
 }


### PR DESCRIPTION
This backports `AlwaysAllowMultiInstanceSplit` to SDK 33.